### PR TITLE
Update cuda libraries for latest pytorch

### DIFF
--- a/libcom/controllable_composition/controllable_composition.py
+++ b/libcom/controllable_composition/controllable_composition.py
@@ -23,6 +23,7 @@ except:
     pass
 from torch import device
 import torchvision
+from transformers.utils import cached_file
 from .source.ControlCom.ldm.util import instantiate_from_config
 from .source.ControlCom.ldm.models.diffusion.ddim import DDIMSampler
 from .source.ControlCom.ldm.models.diffusion.plms import PLMSSampler
@@ -73,19 +74,21 @@ class ControlComModel:
         self.model_type = model_type
         self.option = kwargs
         
-        weight_path = os.path.join(cur_dir, 'pretrained_models', 'ControlCom.pth')
-        download_pretrained_model(weight_path)
+        #weight_path = os.path.join(cur_dir, 'pretrained_models', 'ControlCom.pth')
+        #download_pretrained_model(weight_path)
         
         self.device = check_gpu_device(device)
         self.build_pretrained_model(weight_path)
         self.build_data_transformer()
 
     def build_pretrained_model(self, weight_path):
-        pl_sd  = torch.load(weight_path, map_location="cpu")
+        #pl_sd  = torch.load(weight_path, map_location="cpu")
+        pl_sd = torch.load(cached_file("BCMIZB/Libcom_pretrained_models", "ControlCom.pth"))
         sd     = pl_sd["state_dict"]
         config = OmegaConf.load(os.path.join(cur_dir, 'source/ControlCom/configs/controlcom.yaml'))
-        clip_path = os.path.join(cur_dir, '../shared_pretrained_models', 'openai-clip-vit-large-patch14')
-        download_entire_folder(clip_path)
+        #clip_path = os.path.join(cur_dir, '../shared_pretrained_models', 'openai-clip-vit-large-patch14')
+        #download_entire_folder(clip_path)
+        clip_path = "openai/clip-vit-large-patch14"
         config.model.params.cond_stage_config.params.version = clip_path
         model  = instantiate_from_config(config.model)
         model.load_state_dict(sd, strict=False)

--- a/libcom/image_harmonization/source/trilinear_cpp/src/trilinear_cuda.cpp
+++ b/libcom/image_harmonization/source/trilinear_cpp/src/trilinear_cuda.cpp
@@ -1,6 +1,7 @@
 #include "trilinear_kernel.h"
 #include <torch/extension.h>
-#include <THC/THC.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAEvent.h>
 
 int trilinear_forward_cuda(torch::Tensor lut, torch::Tensor image, torch::Tensor output,
                            int lut_dim, int shift, float binsize, int width, int height, int batch)
@@ -9,8 +10,9 @@ int trilinear_forward_cuda(torch::Tensor lut, torch::Tensor image, torch::Tensor
     float * lut_flat = lut.data<float>();
     float * image_flat = image.data<float>();
     float * output_flat = output.data<float>();
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-    TriLinearForwardLaucher(lut_flat, image_flat, output_flat, lut_dim, shift, binsize, width, height, batch, at::cuda::getCurrentCUDAStream());
+    TriLinearForwardLaucher(lut_flat, image_flat, output_flat, lut_dim, shift, binsize, width, height, batch, stream);
 
     return 1;
 }
@@ -22,14 +24,14 @@ int trilinear_backward_cuda(torch::Tensor image, torch::Tensor image_grad, torch
     float * image_grad_flat = image_grad.data<float>();
     float * image_flat = image.data<float>();
     float * lut_grad_flat = lut_grad.data<float>();
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-    TriLinearBackwardLaucher(image_flat, image_grad_flat, lut_grad_flat, lut_dim, shift, binsize, width, height, batch, at::cuda::getCurrentCUDAStream());
+    TriLinearBackwardLaucher(image_flat, image_grad_flat, lut_grad_flat, lut_dim, shift, binsize, width, height, batch, stream);
 
     return 1;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("forward", &trilinear_forward_cuda, "Trilinear forward");
-  m.def("backward", &trilinear_backward_cuda, "Trilinear backward");
+  m.def("trilinear_forward_cuda", &trilinear_forward_cuda, "Trilinear forward");
+  m.def("trilinear_backward_cuda", &trilinear_backward_cuda, "Trilinear backward");
 }
-

--- a/libcom/image_harmonization/source/trilinear_cpp/src/trilinear_kernel.h
+++ b/libcom/image_harmonization/source/trilinear_cpp/src/trilinear_kernel.h
@@ -1,7 +1,8 @@
 #ifndef _TRILINEAR_KERNEL
 #define _TRILINEAR_KERNEL
 
-#include <THC/THC.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAEvent.h>
 
 __global__ void TriLinearForward(const int nthreads, const float* lut, const float* image, float* output, const int dim, const int shift, const float binsize, const int width, const int height, const int batch);
 
@@ -11,6 +12,4 @@ __global__ void TriLinearBackward(const int nthreads, const float* image, const 
 
 int TriLinearBackwardLaucher(const float* image, const float* image_grad, float* lut_grad, const int lut_dim, const int shift, const float binsize, const int width, const int height, const int batch, cudaStream_t stream);
 
-
 #endif
-


### PR DESCRIPTION
# Current problem
The trilinear function depends on an old pytorch version.

# What I do
Replace deprecated modules with current modules.

# Environment
```bash
> nvcc -V
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2022 NVIDIA Corporation
Built on Wed_Sep_21_10:33:58_PDT_2022
Cuda compilation tools, release 11.8, V11.8.89
Build cuda_11.8.r11.8/compiler.31833905_0
> torch.__version__
'2.1.2+cu118'
```