### PR TITLE
Resolve relative path not found in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,15 +95,13 @@ def parse_requirements(fname='requirements.txt', with_version=True):
 def get_ext_modules(cur_dir):
     # if encounter compilation issues, please refer to https://github.com/HuiZeng/Image-Adaptive-3DLUT?tab=readme-ov-file#build.
     if torch.cuda.is_available():
-        return CUDAExtension('trilinear', 
-                             [join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear_cuda.cpp'), 
-                              join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear_kernel.cu')],
-                             )
+        trilinear_cuba_abs_path = join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear_cuda.cpp')
+        trilinear_kernel_abs_path = join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear_kernel.cu')
+        return CUDAExtension('trilinear', [trilinear_cuba_abs_path, trilinear_kernel_abs_path])
     else:
-        return CppExtension('trilinear',  
-                            [join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear.cpp')], 
-                            include_dirs=[join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src')]
-                            )
+        trilinear_abs_path = join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear.cpp')
+        src_abs_path = join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src')
+        return CppExtension('trilinear', [trilinear_abs_path], include_dirs=[src_abs_path]) 
 
 if __name__ == '__main__':
     cur_dir = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 import torch
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CppExtension
 import os
+from os.path import join
 
 
 def readme():
@@ -91,17 +92,17 @@ def parse_requirements(fname='requirements.txt', with_version=True):
     packages = list(gen_packages_items())
     return packages
 
-def get_ext_modules():
+def get_ext_modules(cur_dir):
     # if encounter compilation issues, please refer to https://github.com/HuiZeng/Image-Adaptive-3DLUT?tab=readme-ov-file#build.
     if torch.cuda.is_available():
         return CUDAExtension('trilinear', 
-                             ['libcom/image_harmonization/source/trilinear_cpp/src/trilinear_cuda.cpp', 
-                              'libcom/image_harmonization/source/trilinear_cpp/src/trilinear_kernel.cu'],
+                             [join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear_cuda.cpp'), 
+                              join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear_kernel.cu')],
                              )
     else:
         return CppExtension('trilinear',  
-                            ['libcom/image_harmonization/source/trilinear_cpp/src/trilinear.cpp'], 
-                            include_dirs=['libcom/image_harmonization/source/trilinear_cpp/src']
+                            [join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src/trilinear.cpp')], 
+                            include_dirs=[join(cur_dir, 'libcom/image_harmonization/source/trilinear_cpp/src')]
                             )
 
 if __name__ == '__main__':
@@ -128,7 +129,7 @@ if __name__ == '__main__':
         setup_requires=parse_requirements('requirements/build.txt'),
         tests_require=parse_requirements('requirements/tests.txt'),
         install_requires=parse_requirements('requirements/requirements.txt'),
-        ext_modules=[get_ext_modules()],
+        ext_modules=[get_ext_modules(cur_dir)],
         cmdclass={'build_ext': BuildExtension},
         extras_require={
             'all': parse_requirements('requirements.txt'),


### PR DESCRIPTION
In setup.py::get_ext_modules, CPP file paths are set as relative. Installation raises error that cannot find the file paths. Now add absolute paths based on cur_dir. NOTE: cur_dir must be the project folder.