### PR TITLE
Fix: Tensor Type Issue for `cv2.boxPoints()` in `gen_bbx()` by Explicit Float Conversion

### DIFF
--- a/libcom/shadow_generation/source/cldm/cldm.py
+++ b/libcom/shadow_generation/source/cldm/cldm.py
@@ -373,7 +373,7 @@ class ControlLDM(LatentDiffusion):
                 pred_bbx[i,3] = temp
                 pred_bbx[i,4] = pred_bbx[i,4] - 90
             x, y, w, h, theta = pred_bbx[i,0], pred_bbx[i,1], pred_bbx[i,2], pred_bbx[i,3], pred_bbx[i,4]
-            box = ((x, y), (w, h), theta)
+            box = ((float(x), float(y)), (float(w), float(h)), float(theta))
             box_points = cv2.boxPoints(box)
             ## 训练时添加扰动
             # perturbation = np.random.uniform(-5, 5, box_points.shape)


### PR DESCRIPTION
## Summary

This pull request resolves the parsing error that occurs when OpenCV’s `cv2.boxPoints()` receives PyTorch tensor scalars instead of Python floats. By explicitly converting the tensor values (x, y, w, h, theta) to float, we ensure that the function receives the correct data type for constructing a valid rotated rectangle, preventing the `Can't parse 'box' center point. Sequence item with index 0 has a wrong type` error.

## Changes

In the `gen_bbx()` function, replaced the direct usage of PyTorch tensors with explicit float casts.

Specifically, changed:
```python
box = ((x, y), (w, h), theta)
```

to

```python
box = ((float(x), float(y)), (float(w), float(h)), float(theta))
```

This ensures that each value is a Python float before being passed to `cv2.boxPoints()`.

## Benefits

- Eliminates the `Can't parse 'box' center point` error by providing valid (center, size, angle) inputs to `cv2.boxPoints()`.
- Allows the shadow generation (and any other functionality relying on `gen_bbx()`) to proceed without runtime failures.
- Improves compatibility between PyTorch and OpenCV in scenarios where tensor scalars must be interpreted as floats.

## Testing

- Verified by running the existing `test_shadow_generation.py` within `libcom/tests/`.
- After applying the float conversion, the error no longer occurs, and the shadow generation results are produced successfully.