### PR TITLE
Fix ndarray input handling across model APIs

### DIFF
--- a/libcom/fos_score/fos_score_prediction.py
+++ b/libcom/fos_score/fos_score_prediction.py
@@ -84,11 +84,19 @@ class FOSScoreModel:
         ])
     
     def inputs_preprocess(self, background_image, foreground_image, foreground_mask, bbox):
-        bg  = cv2.cvtColor(read_image_opencv(background_image), cv2.COLOR_BGR2RGB)
+        bg = read_image_opencv(background_image)
+        if isinstance(background_image, str):
+            bg = cv2.cvtColor(bg, cv2.COLOR_BGR2RGB)
         bg_h, bg_w, _ = bg.shape
-        fg = cv2.cvtColor(read_image_opencv(foreground_image), cv2.COLOR_BGR2RGB)
+        fg = read_image_opencv(foreground_image)
+        if isinstance(foreground_image, str):
+            fg = cv2.cvtColor(fg, cv2.COLOR_BGR2RGB)
         if foreground_mask is not None:
-            fg_mask = cv2.cvtColor(read_image_opencv(foreground_mask), cv2.COLOR_BGR2GRAY)
+            fg_mask = read_image_opencv(foreground_mask)
+            if isinstance(foreground_mask, str):
+                fg_mask = cv2.cvtColor(fg_mask, cv2.COLOR_BGR2GRAY)
+            elif fg_mask.ndim == 3:
+                fg_mask = cv2.cvtColor(fg_mask, cv2.COLOR_RGB2GRAY)
             assert fg.shape[:2] == fg_mask.shape
             fg[np.where(fg_mask != 255)] = 128
         x1, y1, x2, y2 = bbox

--- a/libcom/harmony_score/harmony_score_prediction.py
+++ b/libcom/harmony_score/harmony_score_prediction.py
@@ -82,7 +82,8 @@ class HarmonyScoreModel:
         bg_mask = self.mask_transform(Image.fromarray(bg_mask))
         bg_mask = bg_mask.unsqueeze(0).to(self.device)
 
-        image   = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        if isinstance(composite_image, str):
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         image   = self.transform(Image.fromarray(image))
         image   = image.unsqueeze(0).to(self.device)
         return image, bg_mask, fg_mask

--- a/libcom/image_harmonization/image_harmonization.py
+++ b/libcom/image_harmonization/image_harmonization.py
@@ -74,7 +74,8 @@ class ImageHarmonizationModel:
     
     def inputs_preprocess(self, composite_image, composite_mask):
         img = read_image_opencv(composite_image)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if isinstance(composite_image, str):
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         mask = read_mask_opencv(composite_mask) / 255.0
         img_lr = cv2.resize(img, (256, 256))
         mask_lr = cv2.resize(mask, (256, 256))

--- a/libcom/inharmonious_region_localization/inharmonious_region_localization.py
+++ b/libcom/inharmonious_region_localization/inharmonious_region_localization.py
@@ -66,7 +66,8 @@ class InharmoniousLocalizationModel:
     
     def inputs_preprocess(self, composite_image):
         img = read_image_opencv(composite_image)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if isinstance(composite_image, str):
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         img = cv2.resize(img, (256,256))
         img = self.transformer(img).float().to(self.device).unsqueeze(0)
         return img

--- a/libcom/reflection_generation/reflection_generation.py
+++ b/libcom/reflection_generation/reflection_generation.py
@@ -123,7 +123,10 @@ class ReflectionGenerationModel:
         mask_embeddings = torch.zeros((1, 64, 2048), dtype=torch.float32)
         bbx_region = torch.zeros((1, 512, 512), dtype=torch.float32)
 
-        object_mask = cv2.imread(composite_mask, cv2.IMREAD_GRAYSCALE)
+        if isinstance(composite_mask, str):
+            object_mask = cv2.imread(composite_mask, cv2.IMREAD_GRAYSCALE)
+        else:
+            object_mask = composite_mask
         object_mask = cv2.resize(object_mask, (512, 512))
         object_mask = object_mask.astype(np.float32) / 255.0
         object_mask = torch.from_numpy(object_mask).unsqueeze(0).to(self.device)

--- a/libcom/shadow_generation/shadow_generation.py
+++ b/libcom/shadow_generation/shadow_generation.py
@@ -720,9 +720,16 @@ class ShadowGenerationModel:
                     decoded = decoded.cpu().permute(0,2,3,1).numpy()
                     decoded = (decoded*255).astype(np.uint8)[0]
 
-                    shadowfree_img_cv = cv2.imread(shadowfree_img)
-                    shadowfree_img_cv = cv2.cvtColor(shadowfree_img_cv, cv2.COLOR_BGR2RGB)
-                    object_mask_cv = cv2.imread(object_mask, cv2.IMREAD_GRAYSCALE)
+                    if isinstance(shadowfree_img, str):
+                        shadowfree_img_cv = cv2.imread(shadowfree_img)
+                        shadowfree_img_cv = cv2.cvtColor(shadowfree_img_cv, cv2.COLOR_BGR2RGB)
+                    else:
+                        shadowfree_img_cv = shadowfree_img
+
+                    if isinstance(object_mask, str):
+                        object_mask_cv = cv2.imread(object_mask, cv2.IMREAD_GRAYSCALE)
+                    else:
+                        object_mask_cv = object_mask
 
                     decoded_post = self.post_process(decoded, shadowfree_img_cv, object_mask_cv)
                     decoded_post = cv2.cvtColor(decoded_post, cv2.COLOR_RGB2BGR)


### PR DESCRIPTION
## Summary

Multiple models document `str | numpy.ndarray` inputs but fail when ndarray is actually passed. This PR fixes 6 affected models by adding `isinstance` checks to skip BGR-specific conversions for ndarray inputs.

**Root cause:** `read_image_opencv()` returns BGR for file paths but passes ndarray as-is (assumed RGB). Post-processing and preprocessing code unconditionally applied BGR→RGB conversion or called `cv2.imread()` directly on parameters.

## Changes

- **ShadowGenerationModel** / **ReflectionGenerationModel**: `cv2.imread()` called on ndarray → `TypeError`. Added `isinstance` guard.
- **ImageHarmonizationModel** / **InharmoniousLocalizationModel** / **HarmonyScoreModel** / **FOSScoreModel**: Unconditional `cv2.cvtColor(BGR2RGB)` swaps R/B channels for RGB ndarray. Conditioned on `isinstance(input, str)`.

## Reproduction

```python
import numpy as np
from libcom import ShadowGenerationModel, ImageHarmonizationModel

img = np.zeros((512, 512, 3), dtype=np.uint8)
mask = np.zeros((512, 512), dtype=np.uint8)

# TypeError: cv2.imread receives ndarray
ShadowGenerationModel(device=0)(img, mask, number=1)

# Wrong colors: R/B channels swapped
ImageHarmonizationModel(device=0, model_type='PCTNet')(img, mask)
```